### PR TITLE
Added support for multiple CC and BCC recipients + other settings

### DIFF
--- a/Admin/presenters/SettingsPresenter.php
+++ b/Admin/presenters/SettingsPresenter.php
@@ -2,6 +2,8 @@
 
     namespace AdminModule\FormModule;
 
+    use Nette;
+
     /**
      * Description of SettingsPresenter
      * @author Tomáš Voslař <tomas.voslar at webcook.cz>
@@ -15,7 +17,20 @@
 	}
 
 	protected function beforeRender() {
+	    
 	    parent::beforeRender();
+
+	    // validate FROM email address
+	    $infoFromEmail = $this->settings->get('Info email FROM address', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+	    if (!Nette\Utils\Validators::isEmail($infoFromEmail)) {
+		$this->flashMessage('Please fill in valid FROM email address.', 'warning');
+            }
+	    // validate REPLYTO email address
+	    $infoReplyToEmail = $this->settings->get('Info email REPLYTO address', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+	    if (!Nette\Utils\Validators::isEmail($infoReplyToEmail)) {
+		$this->flashMessage('Please fill in valid REPLY-TO email address.', 'warning');
+            }
+	    
 	}
 
 	public function actionDefault($idPage) {
@@ -25,6 +40,12 @@
 	public function createComponentSettingsForm() {
 
 	    $settings = array();
+	    $settings[] = $this->settings->get('Info email FROM address', 'formModule' . $this->actualPage->getId(), 'text');
+	    $settings[] = $this->settings->get('Info email FROM name', 'formModule' . $this->actualPage->getId(), 'text');
+	    $settings[] = $this->settings->get('Info email REPLYTO address', 'formModule' . $this->actualPage->getId(), 'text');
+	    $settings[] = $this->settings->get('Info email REPLYTO name', 'formModule' . $this->actualPage->getId(), 'text');
+	    $settings[] = $this->settings->get('Info email CC recipients', 'formModule' . $this->actualPage->getId(), 'text');
+	    $settings[] = $this->settings->get('Info email BCC recipients', 'formModule' . $this->actualPage->getId(), 'text');
 	    $settings[] = $this->settings->get('Info email subject', 'formModule' . $this->actualPage->getId(), 'text');
 	    $settings[] = $this->settings->get('Info email', 'formModule' . $this->actualPage->getId(), 'textarea', array());
 
@@ -45,7 +66,7 @@
 		return $item->getRequired() ? 'Yes' : 'No';
 	    });
 
-	    $grid->addActionHref("updateElement", 'Response', 'updateElement', array('idPage' => $this->actualPage->getId()))->getElementPrototype()->addAttributes(array('class' => array('btn', 'btn-primary', 'ajax'), 'data-toggle' => 'modal', 'data-target' => '#myModal', 'data-remote' => 'false'));
+	    $grid->addActionHref("updateElement", 'Edit', 'updateElement', array('idPage' => $this->actualPage->getId()))->getElementPrototype()->addAttributes(array('class' => array('btn', 'btn-primary', 'ajax'), 'data-toggle' => 'modal', 'data-target' => '#myModal', 'data-remote' => 'false'));
 	    $grid->addActionHref("deleteElement", 'Delete', 'deleteElement', array('idPage' => $this->actualPage->getId()))->getElementPrototype()->addAttributes(array('class' => array('btn', 'btn-danger'), 'data-confirm' => 'Are you sure you want to delete this item?'));
 
 	    return $grid;

--- a/Frontend/presenters/FormPresenter.php
+++ b/Frontend/presenters/FormPresenter.php
@@ -151,11 +151,40 @@ class FormPresenter extends \FrontendModule\BasePresenter
 			$mail = new \Nette\Mail\Message;
 			$mail->addTo($infoMail);
 			
-			$domain = str_replace('www.', '', $this->getHttpRequest()->url->host);
+			$mailFrom = $this->settings->get('Info email FROM address', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+			$mailFromName = $this->settings->get('Info email FROM name', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
 			
-			if($domain !== 'localhost') $mail->setFrom('no-reply@' . $domain);
-			else $mail->setFrom('no-reply@test.cz'); // TODO move to settings
+			if(!empty($mailFrom)){
+				$mail->setFrom($mailFrom, $mailFromName);
+			}else{
+				$domain = str_replace('www.', '', $this->getHttpRequest()->url->host); // TODO: this doesn't work if the host is IP address = no default fallback
+				if($domain !== 'localhost') $mail->setFrom('no-reply@' . $domain);
+				else $mail->setFrom('no-reply@test.cz');
+			}
 
+			$mailReplyTo = $this->settings->get('Info email REPLYTO address', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+			$mailReplyToName = $this->settings->get('Info email REPLYTO name', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+
+			if(!empty($mailReplyTo)) $mail->addReplyTo($mailReplyTo , $mailReplyToName);
+
+			$mailCc = $this->settings->get('Info email CC recipients', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+			
+			if(!empty($mailCc)){
+				$cc = explode(';', $mailCc);
+				foreach($cc as $key => $value){
+					$mail->addCc($value);
+				}
+			}
+
+			$mailBcc = $this->settings->get('Info email BCC recipients', 'formModule' . $this->actualPage->getId(), 'text')->getValue();
+			
+			if(!empty($mailBcc)){
+				$bcc = explode(';', $mailBcc);
+				foreach($bcc as $key => $value){
+					$mail->addBcc($value);
+				}
+			}
+			
 			$mail->setSubject($this->settings->get('Info email subject', 'formModule' . $this->actualPage->getId(), 'text')->getValue());
 			$mail->setHtmlBody($mailBody);
 			


### PR DESCRIPTION
Added new form settings:
- From email
- From name
- ReplyTo email
- ReplyTo name
- CC recipients (multiple addresses separated by ";" supported)
- BCC recipients (multiple addresses separated by ";" supported)

Basic validation of entered From and ReplyTo addresses.
Fixed typo (Response -> Edit).

**TODO:**
Add validation for CC and BCC addresses.